### PR TITLE
Ajout script docker-start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,34 @@
 FROM ubuntu:15.10
-RUN apt-get update
-RUN apt-get install -y php5
-RUN apt-get install -y postgresql-9.4
-RUN apt-get install -y postgis
-RUN apt-get install -y php5-pgsql
-RUN apt-get install -y vim
+
+RUN apt-get update && apt-get install -y \
+  php5 \
+  postgresql-9.4 \
+  postgis \
+  php5-pgsql \
+  git \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/*
 
 # Setup DB
 RUN service postgresql start && su postgres -c "psql -c \"CREATE EXTENSION postgis\""
 RUN service postgresql start && su postgres -c "psql -c \"ALTER USER Postgres WITH PASSWORD 'necmergitur'\""
+
 # Config
 RUN a2enmod rewrite
 ADD deploy/geoalerte.conf /etc/apache2/sites-available/
 RUN a2ensite geoalerte
+
 # App
 RUN mkdir /app
 ADD . /app/
 RUN cd /app && ./composer.phar install
+
 # DB Schema
 RUN service postgresql start && su postgres -c "psql -f /app/create_database.sql"
+
+ADD deploy/docker-start.sh /usr/local/bin/
+RUN chmod a+rx /usr/local/bin/docker-start.sh
+
+CMD ["/usr/local/bin/docker-start.sh"]
+
+EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -19,14 +19,26 @@ Une alerte est consituée :
 - d'une emprise géographique
 
 
-##L'API
+## L'API
 
 C'est un backoffice qui propose une API permettant de
 - Pousser les évennement géolocalisés (autorités certifées)
 - Consommer les données (sites, applis mobiles, administrations...)
 
-##Docker
+## Docker
+
 Vous pouvez tester le projet avec docker (installation préalable nécessaire)
+
+### Quick start
+
+```shell
+docker run -d -p 8000:8000 cimi/geoalerte
+```
+
+Puis, aller sur la page http://127.0.0.1:8000
+
+### Build son image
+
 ```shell
 # Récupérer le dépôt
 git clone https://github.com/communaute-cimi/nm-geoalerte-back
@@ -41,10 +53,9 @@ docker run -p 8000:8000 -d geoalerte /bin/bash -c "service postgresql start && a
 
 # accéder à la VM (container_id = 3 premiers caractères de l'ID)
 docker exec -it ${container_id} /bin/bash
-
 ```
 
-##Pile technique
+## Pile technique
 
 - OS : Unbuntu 15.10
 - Langage : PHP + framework slim (pour l'API)

--- a/deploy/docker-start.sh
+++ b/deploy/docker-start.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+service postgresql start &&
+apache2ctl -X &&
+tail -f /var/log/apache2/*.log


### PR DESCRIPTION
Proposition de modifications pour le Dockerfile qui permet de faire : 

```
docker run -P -d cimi/geoalerte
```

ou 

```
docker run -p 8000:8000 -d cimi/geoalerte
```
